### PR TITLE
Remove any commas from values in patchdata.php

### DIFF
--- a/patchdata.php
+++ b/patchdata.php
@@ -1,9 +1,9 @@
 <?php
-define(filename, "data.txt");
-define(maxlength, 1024);
+define("filename", "data.txt");
+define("maxlength", 1024);
 define("max", 11000);
 define("separator", ",");
-define(needle, "=");
+define("needle", "=");
 $entityBody = file_get_contents('php://input');
 $entityBody = substr($entityBody, 0, maxlength);
 $pos = strpos($entityBody, needle);
@@ -17,6 +17,8 @@ if ($pos !== false)
         if (is_numeric($index) && $index >= 0)
         {
             $value = substr($entityBody, $pos+1);
+            // Comma is the delimiter in our csv file and may never be part of a value
+            $value = str_replace(",", "", $value);
 
             if (($handle = fopen(filename, "r")) !== FALSE)
             {


### PR DESCRIPTION
Replaces commas with empty string as comma is our delimiter and cannot be part of a value. This prevents someone from writing an arbitrary amount of characters into _data.txt_.

I also had to put some constant names in quotes as the `define` method expects a string as the first parameter. Maybe using define without quotes works on older php versions but it did not for me.